### PR TITLE
chore: Use ~1.20.1 to support 1.20.4

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -27,7 +27,7 @@
   ],
   "depends": {
     "fabricloader": ">=${loader_version}",
-    "minecraft": "${minecraft_version}",
+    "minecraft": "~${minecraft_version}",
     "fabric": "*",
     "fabric-language-kotlin": ">=1.10.8+kotlin.1.9.0"
   }


### PR DESCRIPTION
After some quick testing the mod showed to work fine on 1.20.4, but required a dependency override, this makes so the override isn't required anymore